### PR TITLE
optimize Future.onFailure, recover, recoverWith not to dispatch in happy case

### DIFF
--- a/src/library/scala/concurrent/impl/Promise.scala
+++ b/src/library/scala/concurrent/impl/Promise.scala
@@ -72,7 +72,7 @@ private final class DispatchingCallback[T](val executor: ExecutionContext, val o
   }
 }
 
-private final class MultiStageCallback[T, U](executor: ExecutionContext, firstStage: (Try[T], U => Unit) => Unit, secondStage: U => Unit) extends Callback[T] with Runnable {
+private final class MultiStageCallback[T, U](executor: ExecutionContext, firstStage: (Try[T], U => Unit) => Unit, secondStage: U => Unit) extends Callback[T] with OnCompleteRunnable with Runnable {
   private[this] var _u: U = _
 
   final def run(): Unit = try secondStage(_u) catch { case NonFatal(e) => executor reportFailure e }

--- a/src/library/scala/concurrent/impl/Promise.scala
+++ b/src/library/scala/concurrent/impl/Promise.scala
@@ -52,7 +52,10 @@ private sealed abstract class Callback[T] {
   def executeWithValue(v: Try[T]): Unit
 }
 
-/* Precondition: `executor` is prepared, i.e., `executor` has been returned from invocation of `prepare` on some other `ExecutionContext`.
+/**
+ * A callback that runs the given onComplete function on the given executor.
+ *
+ * Precondition: `executor` is prepared, i.e., `executor` has been returned from invocation of `prepare` on some other `ExecutionContext`.
  */
 private final class DispatchingCallback[T](val executor: ExecutionContext, val onComplete: Try[T] => Any) extends Callback[T] with OnCompleteRunnable with Runnable {
   // must be filled in before running it
@@ -72,6 +75,12 @@ private final class DispatchingCallback[T](val executor: ExecutionContext, val o
   }
 }
 
+/**
+ * A callback that runs the firstStage on the thread that calls the callback, allowing the firstStage to dispatch the
+ * secondStage to run on the given executor.
+ *
+ * Precondition: `executor` is prepared, i.e., `executor` has been returned from invocation of `prepare` on some other `ExecutionContext`.
+ */
 private final class MultiStageCallback[T, U](executor: ExecutionContext, firstStage: (Try[T], U => Unit) => Unit, secondStage: U => Unit) extends Callback[T] with OnCompleteRunnable with Runnable {
   private[this] var _u: U = _
 


### PR DESCRIPTION
In https://github.com/akka/akka/pull/24109 we observed that a simple `Future.onFailure` scheduled using the `sameThreadExecutionContext` caused a 25% slowdown even if no failures were observed at all. This happened in a benchmark that is admittedly very future-heavy. I started to look into it and found out that scheduling even on the `sameThreadExecutionContext` can have significant cost (because of the trampolining inherited from BatchExecutor).

I thought a bit more about it and came to the conclusion that we could prevent a lot of unnecessary dispatching in futures by optimizing `onFailure`, `recover`, and other combinators that only act on the unhappy path not to dispatch anything if the result is a `Success`. The default implementation of those methods is implemented in terms of `onComplete` and `transform(With)` which will already dispatch a runnable just to evaluate if the result of this future was a success or not.

The same consideration also applies for the Success-case methods like `onSuccess`, `map`, `filter`, etc. which would also not have to schedule anything if this future was a failure. However, under assumption that most futures are successful, the big win would be in improving the above failure methods first.

I tried that out below (without yet improving the code structure).

@viktorklang do you think this could be acceptable with some more polish? I glanced over your pending work on Futures but didn't see anything that would improve that particular aspect.